### PR TITLE
Add AWS Aurora PostgreSQL with IAM authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ Below is a list of microservices that require individual PostgreSQL databases:
 
 You can find the script template for database creation at: `./resources/postgres/01_create_databases.sh`.
 
+> **Note:** You can use **AWS RDS Aurora PostgreSQL** instead of local PostgreSQL. See the [Migration Guide](./docs/migration.md) for Aurora setup with IAM authentication.
+
 ### Step 2: Insert Required Data into the PostgreSQL Database
 
 To start using the String editor in plugin mode, you first need to register a plugin in the database of `stripo-plugin-details-service`. This database contains a table named `plugins`.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -9,12 +9,11 @@ This document is designed to assist you in migrating your Stripo environment to 
 - Added support for **AWS Aurora PostgreSQL** with **IAM authentication** as an alternative to the default local PostgreSQL.
   - All plugin microservices can now connect to Aurora PostgreSQL using IAM-based authentication (no passwords required).
   - A new database initialization script `01_create_databases_iam.sh` has been added to automate the setup of databases, users, and IAM roles on Aurora.
-  - The `stripo-aurora-datasource-spring-boot-starter` library handles IAM token generation and SSL configuration automatically.
 
 ### [Action Required](http://stripoemail.com/)
 
 - If you want to use Aurora PostgreSQL with IAM authentication:
-  **Affected services** (require ConfigMap + Deployment changes):
+**Affected services** (require ConfigMap + Deployment changes):
   - `ai-service`
   - `countdowntimer`
   - `stripe-html-gen-service`
@@ -76,7 +75,7 @@ This document is designed to assist you in migrating your Stripo environment to 
     > This is the official AWS RDS root CA certificate bundle. It is used by `countdowntimer` to verify the Aurora server certificate when `DB_SSL_MODE: verify-full`.
   6. Update each service ConfigMap to point to Aurora with IAM settings.
     > **Note:** Skip `countdowntimer` here — it uses a different config format (see step 8).
-     Database and user mapping (from `01_create_databases_iam.sh`):
+    >  Database and user mapping (from `01_create_databases_iam.sh`):
 
     | Service                             | Database                           | Username            |
     | ----------------------------------- | ---------------------------------- | ------------------- |

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -2,6 +2,167 @@
 
 This document is designed to assist you in migrating your Stripo environment to the latest release version.
 
+## Update as of March 06, 2026
+
+### Key Changes
+
+- Added support for **AWS Aurora PostgreSQL** with **IAM authentication** as an alternative to the default local PostgreSQL.
+  - All plugin microservices can now connect to Aurora PostgreSQL using IAM-based authentication (no passwords required).
+  - A new database initialization script `01_create_databases_iam.sh` has been added to automate the setup of databases, users, and IAM roles on Aurora.
+  - The `stripo-aurora-datasource-spring-boot-starter` library handles IAM token generation and SSL configuration automatically.
+
+### [Action Required](http://stripoemail.com/)
+
+- If you want to use Aurora PostgreSQL with IAM authentication:
+  **Affected services** (require ConfigMap + Deployment changes):
+  - `ai-service`
+  - `countdowntimer`
+  - `stripe-html-gen-service`
+  - `stripo-plugin-custom-blocks-service`
+  - `stripo-plugin-details-service`
+  - `stripo-plugin-documents-service`
+  - `stripo-plugin-drafts-service`
+  - `stripo-plugin-image-bank-service`
+  - `stripo-plugin-statistics-service`
+  - `stripo-security-service`
+  - `stripo-timer-api`
+  1. Create an Aurora PostgreSQL cluster with **IAM authentication enabled**.
+  2. Create an IAM user and attach a policy with `rds-db:connect` permission for each database user.
+    Save the following JSON to `policy.json`, replacing `<region>`, `<account-id>`, and `<cluster-resource-id>` with your values:
+    ```json
+    {
+      "Version": "2012-10-17",
+      "Statement": [{
+        "Effect": "Allow",
+        "Action": "rds-db:connect",
+        "Resource": [
+          "arn:aws:rds-db:<region>:<account-id>:dbuser:<cluster-resource-id>/user_ai_service",
+          "arn:aws:rds-db:<region>:<account-id>:dbuser:<cluster-resource-id>/user_bank_images",
+          "arn:aws:rds-db:<region>:<account-id>:dbuser:<cluster-resource-id>/user_countdowntimer",
+          "arn:aws:rds-db:<region>:<account-id>:dbuser:<cluster-resource-id>/user_custom_blocks",
+          "arn:aws:rds-db:<region>:<account-id>:dbuser:<cluster-resource-id>/user_documents",
+          "arn:aws:rds-db:<region>:<account-id>:dbuser:<cluster-resource-id>/user_drafts",
+          "arn:aws:rds-db:<region>:<account-id>:dbuser:<cluster-resource-id>/user_html_gen",
+          "arn:aws:rds-db:<region>:<account-id>:dbuser:<cluster-resource-id>/user_plugin_details",
+          "arn:aws:rds-db:<region>:<account-id>:dbuser:<cluster-resource-id>/user_plugin_stats",
+          "arn:aws:rds-db:<region>:<account-id>:dbuser:<cluster-resource-id>/user_securitydb",
+          "arn:aws:rds-db:<region>:<account-id>:dbuser:<cluster-resource-id>/user_timers"
+        ]
+      }]
+    }
+    ```
+    Then run:
+    > **Save the `create-access-key` output** — `AccessKeyId` and `SecretAccessKey` are shown only once and are needed in step 4.
+  3. Run `resources/postgres/01_create_databases_iam.sh` to create databases and IAM-enabled users.
+    Prerequisites: machine with network access to Aurora and `psql` installed.
+     Required environment variables:
+    - `PGHOST` — Aurora cluster writer endpoint
+    - `PGPASSWORD` — Aurora master password
+    - `CLUSTER_RESOURCE_ID` — from step 2
+    - `AWS_ACCOUNT` — AWS account ID
+    - `AWS_REGION` — AWS region (optional, defaults to `eu-west-1`)
+     Example:
+  4. Create a Kubernetes secret with AWS credentials for IAM token generation:
+    ```shell
+     kubectl create secret generic aurora-db-credentials -n <namespace> \
+       --from-literal=access-key-id=<AWS_ACCESS_KEY_ID> \
+       --from-literal=secret-access-key=<AWS_SECRET_ACCESS_KEY>
+    ```
+  5. Download the Amazon RDS CA bundle and create a ConfigMap (required for SSL certificate verification by `countdowntimer`):
+    ```shell
+     curl -o global-bundle.pem https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
+     kubectl create configmap rds-ca-bundle -n <namespace> --from-file=global-bundle.pem
+    ```
+    > This is the official AWS RDS root CA certificate bundle. It is used by `countdowntimer` to verify the Aurora server certificate when `DB_SSL_MODE: verify-full`.
+  6. Update each service ConfigMap to point to Aurora with IAM settings.
+    > **Note:** Skip `countdowntimer` here — it uses a different config format (see step 8).
+     Database and user mapping (from `01_create_databases_iam.sh`):
+
+    | Service                             | Database                           | Username            |
+    | ----------------------------------- | ---------------------------------- | ------------------- |
+    | ai-service                          | ai_service                         | user_ai_service     |
+    | stripe-html-gen-service             | stripo_plugin_local_html_gen       | user_html_gen       |
+    | stripo-plugin-custom-blocks-service | stripo_plugin_local_custom_blocks  | user_custom_blocks  |
+    | stripo-plugin-details-service       | stripo_plugin_local_plugin_details | user_plugin_details |
+    | stripo-plugin-documents-service     | stripo_plugin_local_documents      | user_documents      |
+    | stripo-plugin-drafts-service        | stripo_plugin_local_drafts         | user_drafts         |
+    | stripo-plugin-image-bank-service    | stripo_plugin_local_bank_images    | user_bank_images    |
+    | stripo-plugin-statistics-service    | stripo_plugin_local_plugin_stats   | user_plugin_stats   |
+    | stripo-security-service             | stripo_plugin_local_securitydb     | user_securitydb     |
+    | stripo-timer-api                    | stripo_plugin_local_timers         | user_timers         |
+
+     ConfigMap properties for each Java/Spring service:
+    > **Important:** Each property must be on its **own line**. Do not combine multiple properties on one line.
+    > `spring.datasource.password` must be **empty** — the IAM token is generated at runtime.
+    > If your ConfigMap contains both `application.properties` and `base.properties`, **both files must be synchronized** — `application.properties` overrides `base.properties`.
+  7. Add AWS environment variables to each service Deployment (excluding `countdowntimer`):
+    ```yaml
+     env:
+       - name: AWS_ACCESS_KEY_ID
+         valueFrom:
+           secretKeyRef:
+             name: aurora-db-credentials
+             key: access-key-id
+       - name: AWS_SECRET_ACCESS_KEY
+         valueFrom:
+           secretKeyRef:
+             name: aurora-db-credentials
+             key: secret-access-key
+       - name: AWS_REGION
+         value: "<aws-region>"
+    ```
+  8. Configure `countdowntimer` — see [countdowntimer Aurora setup](#countdowntimer-aurora-setup) below.
+  9. Restart all affected services and verify:
+    - **Java/Spring services** — logs should contain:
+    - **countdowntimer** — pod starts without errors; no `ConnectionRefusedError` or `KeyError` in logs.
+
+### Countdowntimer Aurora Setup
+
+The `countdowntimer` microservice requires extra steps for Aurora IAM authentication:
+
+1. Update `config.yaml` in the ConfigMap:
+  ```yaml
+   DB_HOST: <aurora-endpoint>
+   DB_PORT: 5432
+   DB_NAME: countdowntimer
+   DB_USER: user_countdowntimer
+   DB_PASSWORD: unused_iam_override
+   DB_USE_IAM: true
+   DB_SSL_MODE: verify-full
+   DB_SSL_CA_PATH: /usr/local/countdowntimer/certs/global-bundle.pem
+   HOST: <your-external-hostname>
+  ```
+  > **Note:** `DB_PASSWORD` must be set to any non-empty value due to a known code limitation.
+  > `HOST` must be set to your **external** hostname used to access the plugin (e.g., `plugins.example.com`). This is used for generating GIF image URLs.
+2. Add environment variables and mount the CA bundle in the Deployment:
+  ```yaml
+   env:
+     - name: AURORA_ENABLED
+       value: "true"
+     - name: AWS_REGION
+       value: "<aws-region>"
+     - name: AWS_ACCESS_KEY_ID
+       valueFrom:
+         secretKeyRef:
+           name: aurora-db-credentials
+           key: access-key-id
+     - name: AWS_SECRET_ACCESS_KEY
+       valueFrom:
+         secretKeyRef:
+           name: aurora-db-credentials
+           key: secret-access-key
+
+   volumeMounts:
+     - name: rds-ca-bundle
+       mountPath: /usr/local/countdowntimer/certs/global-bundle.pem
+       subPath: global-bundle.pem
+
+   volumes:
+     - name: rds-ca-bundle
+       configMap:
+         name: rds-ca-bundle
+  ```
+
 ## Update as of February 19, 2026
 
 ### Key Changes
@@ -13,13 +174,14 @@ This document is designed to assist you in migrating your Stripo environment to 
 ### Action Required
 
 - **Update Helm repository**:
+
 ```shell
 helm repo update stripo
 ```
 
 - If you maintain a custom configuration for `emple-ui`, please update it as follows:
-   - The container now listens on port 8080 instead of 80. Ensure the `containerPort` in your deployment is set to 8080.
-   - Optionally, enforce non-root execution at the Kubernetes level by adding `securityContext.runAsNonRoot: true` to your deployment configuration.
+  - The container now listens on port 8080 instead of 80. Ensure the `containerPort` in your deployment is set to 8080.
+  - Optionally, enforce non-root execution at the Kubernetes level by adding `securityContext.runAsNonRoot: true` to your deployment configuration.
 
 ## Update as of September 26, 2025
 
@@ -28,26 +190,28 @@ helm repo update stripo
 - Hardened `countdowntimer` security. Added support to run the microservice as a non‑root user via `securityContext.runAsUser: 1000`.
 
 ### Action Required
+
 - **Update Helm repository**:
+
 ```shell
 helm repo update stripo
 ```
 
 - If you maintain a custom configuration for `countdowntimer`, please update it as follows:
-   - Change the `ClusterIP` service port from 80 to 8080.
-   - In the `stripo-timer-api` ConfigMap, update the `timer.url` property to `http://countdowntimer:8080/api/` to match the new port.
+  - Change the `ClusterIP` service port from 80 to 8080.
+  - In the `stripo-timer-api` ConfigMap, update the `timer.url` property to `http://countdowntimer:8080/api/` to match the new port.
 
 ## Update as of October 25, 2024
 
 ### Helm Charts
 
 - **Logstash Configuration:**
-   - Relocated the Logstash section from the `ENV` section to the `settings` section, providing a more organized configuration structure.
-
+  - Relocated the Logstash section from the `ENV` section to the `settings` section, providing a more organized configuration structure.
 - **Kubernetes Resources:**
-   - Updated the default resource requests and limits for Kubernetes to optimize performance and ensure efficient resource utilization.
+  - Updated the default resource requests and limits for Kubernetes to optimize performance and ensure efficient resource utilization.
 
 ## Update as of October 09, 2024
+
 We are excited to announce significant improvements and a comprehensive refactoring of all Helm charts and related documentation.
 
 ### Key Changes
@@ -60,9 +224,9 @@ We are excited to announce significant improvements and a comprehensive refactor
 1. **Review Documentation**: Please read the updated `README.md` to understand the changes.
 2. **Sync Your Deployment**: Align your deployment with the provided Helm examples.
 3. **Update Helm Repository**: Execute the following command to update your Helm repository:
-    ```shell
+  ```shell
     helm repo update stripo
-    ```
+  ```
 
 ## Upgrade to Version 1.125.0
 
@@ -159,5 +323,5 @@ To enable AI feature, modify the `stripo_plugin_local_plugin_details` database, 
 ### Action Required
 
 1. Remove the environment variables `LOGSTASH_HOST` and `LOGSTASH_PORT` from the env section in your `.yaml` files.
-   This is relevant if you do not use Logstash as a logs collector.
+  This is relevant if you do not use Logstash as a logs collector.
 

--- a/resources/postgres/01_create_databases_iam.sh
+++ b/resources/postgres/01_create_databases_iam.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# This script creates databases, IAM-authenticated users, assigns privileges, and configures access for Aurora PostgreSQL.
+# All users use rds_iam role - no passwords, auth via AWS IAM token.
+#
+# Prerequisites:
+# - IAM auth enabled on Aurora cluster
+# - PGSSLMODE=require (Aurora enforces SSL via rds.force_ssl=1)
+# - IAM policy with rds-db:connect for each user (printed at the end)
+
+# Connection parameters
+HOST="${PGHOST:?PGHOST required (Aurora cluster endpoint)}"
+PORT="${PGPORT:-5432}"
+USER="${PGUSER:-postgres}"
+PASSWORD="${PGPASSWORD:?PGPASSWORD required}"
+
+# Export the password and SSL mode to avoid prompting during execution
+export PGPASSWORD=$PASSWORD
+export PGSSLMODE="${PGSSLMODE:-require}"
+
+# Array with database and user information
+databases_users=(
+  # The format is: "database_name user_name"
+  # Each line represents a database with a user for that specific database.
+  # All users authenticate via IAM token (rds_iam role) - no passwords needed.
+  "ai_service user_ai_service"
+  "countdowntimer user_countdowntimer"
+  "stripo_plugin_local_bank_images user_bank_images"
+  "stripo_plugin_local_custom_blocks user_custom_blocks"
+  "stripo_plugin_local_documents user_documents"
+  "stripo_plugin_local_drafts user_drafts"
+  "stripo_plugin_local_html_gen user_html_gen"
+  "stripo_plugin_local_plugin_details user_plugin_details"
+  "stripo_plugin_local_plugin_stats user_plugin_stats"
+  "stripo_plugin_local_securitydb user_securitydb"
+  "stripo_plugin_local_timers user_timers"
+)
+
+# Step 1: Create databases, users, grant rds_iam role, and assign privileges
+# The loop iterates over the list of databases and users, creating each database and user in PostgreSQL.
+for entry in "${databases_users[@]}"; do
+  # Splitting each entry into database and user.
+  IFS=' ' read -r db user <<< "$entry"
+
+  echo "Creating database: $db and user: $user (IAM auth)"
+
+  # Create the database (each CREATE DATABASE must be a separate psql call - cannot run inside a transaction)
+  psql -h $HOST -p $PORT -U $USER -c "CREATE DATABASE $db;" 2>/dev/null || true
+
+  # Create the user with LOGIN capability (no password - IAM token will be used)
+  psql -h $HOST -p $PORT -U $USER -c "CREATE USER $user WITH LOGIN;" 2>/dev/null || true
+
+  # Grant rds_iam role to enable IAM token authentication
+  # IMPORTANT: Once rds_iam is granted, regular password auth will NOT work for this user.
+  # Aurora uses PAM auth for rds_iam users - they MUST authenticate with an IAM token.
+  psql -h $HOST -p $PORT -U $USER -c "GRANT rds_iam TO $user;" 2>/dev/null || true
+
+  # Grant all privileges to the user on the newly created database
+  psql -h $HOST -p $PORT -U $USER -c "GRANT ALL PRIVILEGES ON DATABASE $db TO $user;"
+
+  echo "Database $db and user $user created with IAM auth privileges."
+done
+
+# Step 2: Apply privileges for all existing and future tables in the public schema for the specific user in their own database only
+# This section ensures that proper privileges are set for all current and future tables in the databases.
+for entry in "${databases_users[@]}"; do
+  IFS=' ' read -r db user <<< "$entry"
+
+  echo "Applying privileges to database: $db for user: $user"
+
+  # Grant usage and create on schema public for the specific user
+  psql -h $HOST -p $PORT -U $USER -d "$db" -c "GRANT USAGE, CREATE ON SCHEMA public TO $user;"
+
+  # Grant all privileges on all existing tables in the public schema for the specific user in their own database
+  psql -h $HOST -p $PORT -U $USER -d "$db" -c "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO $user;"
+
+  # Grant all privileges on all existing sequences in the public schema for the specific user in their own database
+  psql -h $HOST -p $PORT -U $USER -d "$db" -c "GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO $user;"
+
+  # Set default privileges for future tables for the specific user in their own database
+  psql -h $HOST -p $PORT -U $USER -d "$db" -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON TABLES TO $user;"
+
+  # Set default privileges for future sequences for the specific user in their own database
+  psql -h $HOST -p $PORT -U $USER -d "$db" -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON SEQUENCES TO $user;"
+
+  echo "Privileges applied to $db for user: $user"
+done
+
+# Step 3: Print IAM policy resources for reference
+# These ARNs must be added to the IAM policy with rds-db:connect action.
+CLUSTER_RESOURCE_ID="${CLUSTER_RESOURCE_ID:-<YOUR_CLUSTER_RESOURCE_ID>}"
+AWS_ACCOUNT="${AWS_ACCOUNT:-<YOUR_AWS_ACCOUNT>}"
+AWS_REGION="${AWS_REGION:-eu-west-1}"
+
+echo ""
+echo "Privileges applied to all databases for their respective users"
+echo ""
+echo "IAM policy resources (add to rds-db:connect policy):"
+for entry in "${databases_users[@]}"; do
+  IFS=' ' read -r db user <<< "$entry"
+  echo "  arn:aws:rds-db:${AWS_REGION}:${AWS_ACCOUNT}:dbuser:${CLUSTER_RESOURCE_ID}/$user"
+done
+echo ""
+echo "Get CLUSTER_RESOURCE_ID:"
+echo "  aws rds describe-db-clusters --db-cluster-identifier <name> --query 'DBClusters[0].DbClusterResourceId' --output text"


### PR DESCRIPTION
- Add 01_create_databases_iam.sh script for Aurora database setup
- Update migration.md with Aurora IAM setup guide and IAM policy example
- Add note in README.md about Aurora as alternative to local PostgreSQL